### PR TITLE
Add general-purpose S3 and Bedrock prompt Terraform modules

### DIFF
--- a/bedrock/prompt/main.tf
+++ b/bedrock/prompt/main.tf
@@ -1,0 +1,19 @@
+resource "aws_bedrockagent_prompt" "this" {
+  name        = var.prompt_name
+  description = var.description
+  tags        = var.tags
+
+  default_variant = var.default_variant
+
+  variant {
+    name          = var.default_variant
+    template_type = "TEXT"
+    model_id      = var.model_id
+
+    template_configuration {
+      text {
+        text = var.system_prompt
+      }
+    }
+  }
+}

--- a/bedrock/prompt/outputs.tf
+++ b/bedrock/prompt/outputs.tf
@@ -1,0 +1,14 @@
+output "prompt_id" {
+  value       = aws_bedrockagent_prompt.this.id
+  description = "The ID of the Bedrock managed prompt"
+}
+
+output "prompt_arn" {
+  value       = aws_bedrockagent_prompt.this.arn
+  description = "The ARN of the Bedrock managed prompt"
+}
+
+output "prompt_version" {
+  value       = aws_bedrockagent_prompt.this.version
+  description = "The version of the Bedrock managed prompt"
+}

--- a/bedrock/prompt/variables.tf
+++ b/bedrock/prompt/variables.tf
@@ -1,0 +1,32 @@
+variable "prompt_name" {
+  type        = string
+  description = "Name of the Bedrock managed prompt"
+}
+
+variable "description" {
+  type        = string
+  default     = null
+  description = "Optional description of the prompt"
+}
+
+variable "default_variant" {
+  type        = string
+  default     = "default"
+  description = "Name of the default prompt variant"
+}
+
+variable "model_id" {
+  type        = string
+  description = "Bedrock foundation model ID to associate with this prompt"
+}
+
+variable "system_prompt" {
+  type        = string
+  description = "System prompt text stored as a managed Bedrock prompt"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags to apply to the prompt resource"
+}

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -1,0 +1,32 @@
+resource "aws_s3_bucket" "this" {
+  bucket        = var.bucket_name
+  force_destroy = var.force_destroy
+  tags          = var.tags
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  versioning_configuration {
+    status = var.versioning_enabled ? "Enabled" : "Suspended"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/s3/outputs.tf
+++ b/s3/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_id" {
+  value       = aws_s3_bucket.this.id
+  description = "The name of the bucket"
+}
+
+output "bucket_arn" {
+  value       = aws_s3_bucket.this.arn
+  description = "The ARN of the bucket"
+}
+
+output "bucket_name" {
+  value       = aws_s3_bucket.this.bucket
+  description = "The bucket name"
+}

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -1,0 +1,22 @@
+variable "bucket_name" {
+  type        = string
+  description = "Globally unique name for the S3 bucket"
+}
+
+variable "force_destroy" {
+  type        = bool
+  default     = false
+  description = "Allow bucket deletion even when it contains objects"
+}
+
+variable "versioning_enabled" {
+  type        = bool
+  default     = true
+  description = "Enable versioning on the bucket"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Tags to apply to all resources"
+}


### PR DESCRIPTION
## Summary

- Adds a general-purpose `s3/` Terraform module — versioning, AES256 encryption, and full public access block enabled by default
- Adds a `bedrock/prompt/` Terraform module — manages system prompts as versioned IaC resources via `aws_bedrockagent_prompt`

Both modules follow the existing flat module pattern and are consumed via Terragrunt remote source references.

## Modules

### `s3/`
| Variable | Default | Description |
|----------|---------|-------------|
| `bucket_name` | required | Globally unique bucket name |
| `versioning_enabled` | `true` | S3 versioning |
| `force_destroy` | `false` | Allow non-empty bucket deletion |
| `tags` | `{}` | Resource tags |

### `bedrock/prompt/`
| Variable | Default | Description |
|----------|---------|-------------|
| `prompt_name` | required | Prompt name in Bedrock |
| `model_id` | required | Foundation model to associate |
| `system_prompt` | required | Prompt text content |
| `description` | `null` | Optional description |
| `tags` | `{}` | Resource tags |

## First consumers
These modules are referenced by the `wifi-neural-observer` Terragrunt configs in the `bedrock` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)